### PR TITLE
Integrate documentation into web-page #90

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -49,6 +49,23 @@ pluralizeListTitles = false
   twitter = "ECDTools"
   youtube = "EclipseFdn"
   linkedin = "company/eclipse-foundation/"
+  
+[security.exec]
+  allow = ["^asciidoctor$"]
+
+[module]
+  [[module.mounts]]
+    source = "content"
+    target = "content"
+  [[module.mounts]]
+    source = "submodules/4diac-documentation/src"
+    target = "content/doc"
+
+[markup]
+  [markup.asciidocExt]
+    workingFolderCurrent = true  # Include paths relative to the file
+  [markup.asciidocExt.attributes]
+      skip-front-matter = "true"  # Tell Asciidoctor to ignore Hugo's front matter
 
 [permalinks]
   news = "/:sections/:year/:slug/"
@@ -262,19 +279,19 @@ pluralizeListTitles = false
 
 [[menu.main]]
   name = "Documentation Start"
-  url = "https://github.com/eclipse-4diac/4diac-documentation/blob/main/src/index.adoc"
+  url = "/doc"
   weight = 1
   parent = "doc-getting_started"
 
 [[menu.main]]
   name = "Learn about IEC 61499"
-  url = "https://github.com/eclipse-4diac/4diac-documentation/blob/main/src/intro/iec61499.adoc"
+  url = "/doc/intro/iec61499.html"
   weight = 2
   parent = "doc-getting_started"
 
 [[menu.main]]
   name = "Understand the Eclipse 4diac Framework"
-  url = "https://github.com/eclipse-4diac/4diac-documentation/blob/main/src/intro/4diacFramework.adoc"
+  url = "/doc/intro/4diacFramework.html"
   weight = 3
   parent = "doc-getting_started"
 
@@ -286,25 +303,25 @@ pluralizeListTitles = false
 
 [[menu.main]]
   name = "Step by Step Tutorials"
-  url = "https://github.com/eclipse-4diac/4diac-documentation/blob/main/src/tutorials/index.adoc"
+  url = "/doc/tutorials/overview.html"
   weight = 1
   parent = "doc-using"
 
 [[menu.main]]
   name = "Install Eclipse 4diac"
-  url = "https://github.com/eclipse-4diac/4diac-documentation/blob/main/src/installation/index.adoc"
+  url = "/doc/installation/installation.html"
   weight = 2
   parent = "doc-using"
 
 [[menu.main]]
   name = "4diac IDE Examples"
-  url = "https://github.com/eclipse-4diac/4diac-documentation/blob/main/src/examples/index.adoc"
+  url = "/doc/examples/examples.html"
   weight = 3
   parent = "doc-using"
 
 [[menu.main]]
   name = "Frequently Asked Questions"
-  url = "https://github.com/eclipse-4diac/4diac-documentation/blob/main/src/faq.adoc"
+  url = "/doc/faq.html"
   weight = 4
   parent = "doc-using"
   
@@ -316,19 +333,19 @@ pluralizeListTitles = false
 
 [[menu.main]]
   name = "IO Configuration for the Different Platforms"
-  url = "https://github.com/eclipse-4diac/4diac-documentation/blob/main/src/io_config/index.adoc"
+  url = "/doc/io_config/io_config.html"
   weight = 1
   parent = "doc-details"
 
 [[menu.main]]
   name = "Communication Protocols"
-  url = "https://github.com/eclipse-4diac/4diac-documentation/blob/main/src/communication/index.adoc"
+  url = "/doc/communication/communication.html"
   weight = 2
   parent = "doc-details"
 
 [[menu.main]]
   name = "Development of 4diac FORTE and 4diac IDE"
-  url = "https://github.com/eclipse-4diac/4diac-documentation/blob/main/src/development/index.adoc"
+  url = "/doc/development/development.html"
   weight = 2
   parent = "doc-details"
 


### PR DESCRIPTION
With this commit the documentation is pulled in as subrepository linked into the content area and added to our main menu. This now generates hmtl files of our documentation with 4diac web-page headers and footers and integrated navigation.

Fixes https://github.com/eclipse-4diac/4diac-website-hugo/issues/90