### PR TITLE
Bring back Asciidoc documentation integration into web-page

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ spec:
       - name: "HOME"
         value: "/home/jenkins"
     - name: hugo
-      image: eclipsecbi/hugo_extended:0.110.0
+      image: eclipsefdn/hugo-node:h0.144.2-n22.14.0
       command:
       - cat
       tty: true

--- a/config.toml
+++ b/config.toml
@@ -49,6 +49,23 @@ pluralizeListTitles = false
   twitter = "ECDTools"
   youtube = "EclipseFdn"
   linkedin = "company/eclipse-foundation/"
+  
+[security.exec]
+  allow = ["^asciidoctor$"]
+
+[module]
+  [[module.mounts]]
+    source = "content"
+    target = "content"
+  [[module.mounts]]
+    source = "submodules/4diac-documentation/src"
+    target = "content/doc"
+
+[markup]
+  [markup.asciidocExt]
+    workingFolderCurrent = true  # Include paths relative to the file
+  [markup.asciidocExt.attributes]
+      skip-front-matter = "true"  # Tell Asciidoctor to ignore Hugo's front matter
 
 [permalinks]
   news = "/:sections/:year/:slug/"
@@ -262,19 +279,19 @@ pluralizeListTitles = false
 
 [[menu.main]]
   name = "Documentation Start"
-  url = "https://github.com/eclipse-4diac/4diac-documentation/blob/main/src/_index.adoc"
+  url = "/doc"
   weight = 1
   parent = "doc-getting_started"
 
 [[menu.main]]
   name = "Learn about IEC 61499"
-  url = "https://github.com/eclipse-4diac/4diac-documentation/blob/main/src/intro/iec61499.adoc"
+  url = "/doc/intro/iec61499.html"
   weight = 2
   parent = "doc-getting_started"
 
 [[menu.main]]
   name = "Understand the Eclipse 4diac Framework"
-  url = "https://github.com/eclipse-4diac/4diac-documentation/blob/main/src/intro/4diacFramework.adoc"
+  url = "/doc/intro/4diacFramework.html"
   weight = 3
   parent = "doc-getting_started"
 
@@ -286,25 +303,25 @@ pluralizeListTitles = false
 
 [[menu.main]]
   name = "Step by Step Tutorials"
-  url = "https://github.com/eclipse-4diac/4diac-documentation/blob/main/src/tutorials/tutorials.adoc"
+  url = "/doc/tutorials/overview.html"
   weight = 1
   parent = "doc-using"
 
 [[menu.main]]
   name = "Install Eclipse 4diac"
-  url = "https://github.com/eclipse-4diac/4diac-documentation/blob/main/src/installation/installation.adoc"
+  url = "/doc/installation/installation.html"
   weight = 2
   parent = "doc-using"
 
 [[menu.main]]
   name = "4diac IDE Examples"
-  url = "https://github.com/eclipse-4diac/4diac-documentation/blob/main/src/examples/examples.adoc"
+  url = "/doc/examples/examples.html"
   weight = 3
   parent = "doc-using"
 
 [[menu.main]]
   name = "Frequently Asked Questions"
-  url = "https://github.com/eclipse-4diac/4diac-documentation/blob/main/src/faq.adoc"
+  url = "/doc/faq.html"
   weight = 4
   parent = "doc-using"
   
@@ -316,19 +333,19 @@ pluralizeListTitles = false
 
 [[menu.main]]
   name = "IO Configuration for the Different Platforms"
-  url = "https://github.com/eclipse-4diac/4diac-documentation/blob/main/src/io_config/io_config.adoc"
+  url = "/doc/io_config/io_config.html"
   weight = 1
   parent = "doc-details"
 
 [[menu.main]]
   name = "Communication Protocols"
-  url = "https://github.com/eclipse-4diac/4diac-documentation/blob/main/src/communication/communication.adoc"
+  url = "/doc/communication/communication.html"
   weight = 2
   parent = "doc-details"
 
 [[menu.main]]
   name = "Development of 4diac FORTE and 4diac IDE"
-  url = "https://github.com/eclipse-4diac/4diac-documentation/blob/main/src/development/development.adoc"
+  url = "/doc/development/development.html"
   weight = 2
   parent = "doc-details"
 


### PR DESCRIPTION
With the updated hugo-node image from Eclipse foundation we now have asciidoctor support for hugo pages.

This fixes:
https://github.com/eclipse-4diac/4diac-website-hugo/issues/90