### PR TITLE
Added basic infrastructure for new and noteworthy pages

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -123,6 +123,13 @@ timeout = "120s"
   url = "/4diac_SYS/"
   weight = 6
   parent = "fordiac-projects"
+  
+[[menu.main]]
+  name = "New & Noteworthy"
+  url = "/new-and-noteworthy/"
+  weight = 7
+  parent = "fordiac-projects"
+
 
 [[menu.main]]
   name = "Our Community"

--- a/content/new-and-noteworthy/3.0/4diacFBE.md
+++ b/content/new-and-noteworthy/3.0/4diacFBE.md
@@ -1,0 +1,12 @@
+---
+title: 4diac FBE
+
+---
+
+ - New component in 4diac 3.0
+ - 4diac FBE builds 4diac FORTE fully automatically, no manual downloads or installs of third-party software needed
+ - Manages multiple 4diac FORTE configurations for multiple target machines and operating systems on a single developer machine
+ - Integration into 4diac IDE upcoming, a beta-quality setup is available
+
+
+

--- a/content/new-and-noteworthy/3.0/4diacFORTE.md
+++ b/content/new-and-noteworthy/3.0/4diacFORTE.md
@@ -1,0 +1,24 @@
+---
+title: 4diac FORTE
+
+---
+
+ - Support for ARRAYs with arbitrary boundaries [n..m]
+ - Support for variable length ARRAYs [*]
+ - Support for negated outputs ( => NOT)
+ - Fixed casting behavior for type where binary transfer or sign extension is necessary
+ - Added LTIME types
+ - Improved partial ANY_BIT support (comparisons + assignments to partials (non standard))
+ - Improved standard compliance for implicit and explicit casts
+ - Improved STRING support (partial access)
+ - Added all IEC 61131-3 standard functions
+ - Added support for all variadic functions (MIN, MAX, CONCAT, ADD, MUL)
+ - Fixed that now STRINGS and CHARS can be CONCATenated to a STRING
+ - Improved return type support for FUNCTIONS with ANY-type return types
+ - Added standard-conformant FOR loop
+ - Support of high resolution clocks
+ - Fixed representations of TIME data types and ANY_REAL types
+ - Improved support for ANY type IN/OUTs
+ - Fixed SHR/SHL/ROR/ROL to standard conformity
+ - Fixed XOR corner case when BOOL is involved
+ - Changed code base to C++20

--- a/content/new-and-noteworthy/3.0/4diacIDE.md
+++ b/content/new-and-noteworthy/3.0/4diacIDE.md
@@ -1,0 +1,16 @@
+---
+title: 4diac IDE
+
+---
+
+
+
+
+ - Refactoring functions in graphical and textual editors
+ - Validation of IEC 61499 projects, including support for loading and repairing incomplete projects
+ - Completely reworked and largely improved the IEC 61131-3 Structured Text editors
+ - Interpreter for IEC 61131-3 Structured Text allowing testing and debugging of FBs directly in 4diac IDE
+ - Support for named constants
+ - A new library and package system
+ - Added IEC 61131-3 functions and VAR_IN_OUT support
+ - Simplified deployment and monitoring, with the ability to store deployment and monitoring configurations

--- a/content/new-and-noteworthy/3.0/_index.md
+++ b/content/new-and-noteworthy/3.0/_index.md
@@ -1,0 +1,7 @@
+---
+title: Eclipse 4diac 3.0 - New and Noteworthy
+type: "nan-version"
+release_date: "2025-12-10"
+components: ["4diacIDE", "4diacFORTE", "4diacFBE"]
+---
+

--- a/content/new-and-noteworthy/_index.md
+++ b/content/new-and-noteworthy/_index.md
@@ -1,0 +1,13 @@
+---
+title: "New and Noteworthy"
+headline: > 
+  <span class="white">Eclipse 4diac™</span> - New and Noteworthy
+main_content_class: "col-md-25 padding-bottom-30"
+page_css_file: /4diac/css/home.css
+hide_sidebar: false
+hide_page_title: true
+hide_breadcrumb: true
+---
+
+{{< br >}}
+This page links to the recent new and noteworthy changes in the Eclipse 4diac project. 

--- a/layouts/nan-version/list.html
+++ b/layouts/nan-version/list.html
@@ -1,0 +1,42 @@
+
+{{ define "main" }}
+
+<div class="intro">
+  {{ .Content }}
+  
+  {{ $version := .File.Dir | path.Base | strings.TrimSuffix "/" }}
+
+  {{ $releaseDateFormatted := "TBD" }}
+  {{ if .Params.release_date }}
+    {{ $parsed := time .Params.release_date }}
+    {{ $releaseDateFormatted = $parsed.Format "January 2, 2006" }}
+  {{ end }}
+  
+  <p>Welcome to the Eclipse 4diac project! 
+The Eclipse 4diac {{ $version }} release is planned for {{ $releaseDateFormatted }}. 
+Eclipse 4diac can be downloaded from the project's <a href="/4diac/download">downloads page</a>.</p> 
+
+  <p>Here are some of the more noteworthy items available in this release.</p>
+</div>
+
+
+{{ $order := .Params.components }}
+  {{ if $order }}
+    {{ range $order }}
+      {{ $component := . }}
+      {{ with $.GetPage (printf "%s.md" .) }}
+        {{ $sub := . }}
+        {{/* anchor id from slug or urlized title */}}
+        {{ $id := urlize $component}}
+        <h2 id="{{ $id }}">{{ $sub.Title }}</h2>
+        {{ $sub.Content }}
+      {{ end }}
+    {{ end }}
+  {{ else }}
+    <!-- fallback if no component order is defined -->
+    {{ range .Pages.ByWeight }}
+      {{ .Content }}
+    {{ end }}
+  {{ end }}
+
+{{ end }}

--- a/layouts/new-and-noteworthy/list.html
+++ b/layouts/new-and-noteworthy/list.html
@@ -1,0 +1,35 @@
+
+{{ define "main" }}
+
+<div class="intro">
+</div>
+  {{ .Content }}
+
+<ul>
+{{ range sort .Sections "Title" "desc" }}
+  {{ $version := . }}
+  <li>
+    {{ $releaseDateFormatted := "TBD" }}
+    {{ if $version.Params.release_date }}
+        {{ $parsed := time $version.Params.release_date }}
+        {{ $releaseDateFormatted = $parsed.Format "January 2, 2006" }}
+    {{ end }}
+    
+    {{ $versionNr := .File.Dir | path.Base | strings.TrimSuffix "/" }}
+    
+    <a href="{{ .RelPermalink }}"> Eclipse 4diac {{ $versionNr }} release, {{ $releaseDateFormatted }}:</a>
+    <ul>
+      {{ range $comp := $version.Params.components }}
+        {{ $id := urlize . }}
+        {{ with $version.GetPage (printf "%s.md" $comp) }}
+          <li>
+          <a href="{{ $version.RelPermalink }}#{{ $id }}">{{ .Params.title | default .File.BaseFileName }}</a>
+          </li>
+        {{ end }}
+      {{ end }}
+    </ul>
+  </li>
+{{ end }}
+</ul>
+
+{{ end }}


### PR DESCRIPTION
new and noteworthy pages are automatically listed at the overview page in descending order. The content of the version pages is compiled from the component pages. The component pages can also be accessed. The later is for preparation to create different lists (e.g., new and noteworthy of 4diac IDE versions.