### PR TITLE
Improved Size of news cards on main page

### DIFF
--- a/layouts/shortcodes/4diac_main_news_cards.html
+++ b/layouts/shortcodes/4diac_main_news_cards.html
@@ -59,7 +59,7 @@
                     {{ .Title }}
                 </h3>
                 <p><span style="color: #99a6c3; font-weight: bold;">{{ .Date.Format "2 January, 2006" }}</span></p>
-                <p>{{ .Params.description | markdownify }}</p>
+                {{ .Params.description | markdownify }}
             </div>
 
             {{ if isset . "links" }}

--- a/static/css/4diac_adjustments.css
+++ b/static/css/4diac_adjustments.css
@@ -324,3 +324,12 @@ a:visited {
     overflow-wrap: anywhere;
     word-break: break-word;
 }
+
+.card-container .card-panel .panel-body p {
+  margin-top: 15px;
+  margin-bottom: 0px;
+}
+
+.card-container .card-panel .panel-body {
+  padding: 0 1em 0em;
+}


### PR DESCRIPTION
The news cards had some additional unecessary html tags and used to much spacing on the bottom. This lead to a large empty space. This is fixed now.