### PR TITLE
Introducing an extended Eclipse 4diac Color Palette

### DIFF
--- a/design/Eclipse 4diac.gpl
+++ b/design/Eclipse 4diac.gpl
@@ -1,0 +1,79 @@
+GIMP Palette
+Name: Eclipse 4diac CI Colors
+Columns: 4
+################################################################################
+# Copyright (c) 2026 Johannes Kepler University Linz
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Alois Zoitl - initial API and implementation and/or initial documentation
+################################################################################
+# ==================================================
+# 4diac Blues
+# ==================================================
+0   26   63    4diac Blue Dark
+1   34  105    4diac Blue 
+51  78  135    4diac Blue Medium 1
+90  120 170    4diac Blue Medium 2
+153 166 195    4diac Blue Light
+210 220 235    4diac Blue Pale
+234 240 248    4diac Blue Tint
+
+# ==================================================
+# 4diac Orange 
+# ==================================================
+154 86   0    4diac Orange Ultra Dark
+224 130 12    4diac Orange Dark
+255 149 14    4diac Orange
+255 184 90    4diac Orange Light
+255 230 199   4diac Orange Soft
+255 237 204   4diac Orange Pale
+255 246 236   4diac Orange Tint
+
+# ==================================================
+# 4diac Lime
+# ==================================================
+63  95  0     4diac Lime Ultra Dark
+110 161 31    4diac Lime Dark
+140 200 45    4diac Lime
+181 226 106   4diac Lime Light
+231 244 207   4diac Lime Soft
+238 249 220   4diac Lime Pale
+246 251 239   4diac Lime Tint
+
+# ==================================================
+# 4diac Gray
+# ==================================================
+26  26  26    4diac Gray Ultra Dark
+50  50  50    4diac Dark Gray
+102 102 102   4diac Gray Dark
+153 153 153   4diac Gray
+204 204 204   4diac Gray Light
+230 230 230   4diac Gray Pale
+245 245 245   4diac Gray Tint
+
+255 255 255   White
+
+# ==================================================
+# Diagram Semantic Colors (ONLY for Diagrams and Figures)
+# ==================================================
+
+# Event Connection
+181 226 106  Event Light
+99 179 31    Event Base
+77 143 25    Event Dark
+
+# Data Connection
+153 178 255  Data Light
+51 102 255   Data Base
+38 76 204    Data Dark
+
+# Adapter Connection
+185 150 210  Adapter Light
+132 93 175   Adapter Base
+98 75 135    Adapter Dark

--- a/design/Eclipse 4diac.soc
+++ b/design/Eclipse 4diac.soc
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2026 Johannes Kepler University Linz
+
+  This program and the accompanying materials are made available under the
+  terms of the Eclipse Public License 2.0 which is available at
+  http://www.eclipse.org/legal/epl-2.0.
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Contributors:
+    Alois Zoitl - initial API and implementation and/or initial documentation
+-->
+
+<office:color-table
+ xmlns:office="http://openoffice.org/2000/office"
+ xmlns:draw="http://openoffice.org/2000/drawing">
+
+
+
+ <!-- 4diac Blue -->
+ <draw:color draw:name="4diac Blue Ultra Dark" draw:color="#001A3F"/>
+ <draw:color draw:name="4diac Blue " draw:color="#012269"/>
+ <draw:color draw:name="4diac Blue Medium 1" draw:color="#334E87"/>
+ <draw:color draw:name="4diac Blue Medium 2" draw:color="#5A78AA"/>
+ <draw:color draw:name="4diac Blue Light" draw:color="#99A6C3"/>
+ <draw:color draw:name="4diac Blue Pale" draw:color="#D2DCEB"/>
+ <draw:color draw:name="4diac Blue Tint" draw:color="#EAF0F8"/>
+
+ <!-- 4diac Orange -->
+ <draw:color draw:name="4diac Orange Ultra Dark" draw:color="#9A5600"/>
+ <draw:color draw:name="4diac Orange Dark" draw:color="#E0820C"/>
+ <draw:color draw:name="4diac Orange" draw:color="#FF950E"/>
+ <draw:color draw:name="4diac Orange Light" draw:color="#FFB85A"/>
+ <draw:color draw:name="4diac Orange Soft" draw:color="#FFE6C7"/>
+ <draw:color draw:name="4diac Orange Pale" draw:color="#FFEDCC"/>
+ <draw:color draw:name="4diac Orange Tint" draw:color="#FFF6EC"/>
+
+ <!-- 4diac Lime -->
+ <draw:color draw:name="4diac Lime Ultra Dark" draw:color="#3F5F00"/>
+ <draw:color draw:name="4diac Lime Dark" draw:color="#6EA11F"/>
+ <draw:color draw:name="4diac Lime" draw:color="#8CC82D"/>
+ <draw:color draw:name="4diac Lime Light" draw:color="#B5E26A"/>
+ <draw:color draw:name="4diac Lime Soft" draw:color="#E7F4CF"/>
+ <draw:color draw:name="4diac Lime Pale" draw:color="#EEF8DC"/>
+ <draw:color draw:name="4diac Lime Tint" draw:color="#F6FBEF"/>
+
+ <!-- 4diac Gray -->
+ <draw:color draw:name="4diac Gray Ultra Dark" draw:color="#1A1A1A"/>
+ <draw:color draw:name="4diac Dark Gray" draw:color="#323232"/>
+ <draw:color draw:name="4diac Gray Dark" draw:color="#666666"/>
+ <draw:color draw:name="4diac Gray" draw:color="#999999"/>
+ <draw:color draw:name="4diac Gray Light" draw:color="#CCCCCC"/>
+ <draw:color draw:name="4diac Gray Pale" draw:color="#E6E6E6"/>
+ <draw:color draw:name="4diac Gray Tint" draw:color="#F5F5F5"/>
+ 
+ <draw:color draw:name="White" draw:color="#FFFFFF"/>
+
+ <!-- Connection Colors (ONLY for Diagrams and Figures) -->
+
+ <!-- Event -->
+ <draw:color draw:name="Event Light" draw:color="#B5E26A"/>
+ <draw:color draw:name="Event Base" draw:color="#63B31F"/>
+ <draw:color draw:name="Event Dark" draw:color="#4D8F19"/>
+
+ <!-- Data -->
+ <draw:color draw:name="Data Light" draw:color="#99B2FF"/>
+ <draw:color draw:name="Data Base" draw:color="#3366FF"/>
+ <draw:color draw:name="Data Dark" draw:color="#264CCC"/>
+
+ <!-- Adapter -->
+ <draw:color draw:name="Adapter Light" draw:color="#B996D2"/>
+ <draw:color draw:name="Adapter Base" draw:color="#845DAF"/>
+ <draw:color draw:name="Adapter Dark" draw:color="#624B87"/>
+
+</office:color-table>


### PR DESCRIPTION
In order to have more flexibilty and to allow for more rich drawings a color palette with more gradients and a new accent color 4diac Lime are provided. Furthermore colors for events, data, and adapters can help for any diagrams (e.g., documentation).

Three forms of the palette is provided: Gimp (also suitable for Inkscape), Libreoffice, and CSS.

This is how the palette looks in the different tools:

#### Inkscape:
<img width="955" height="178" alt="Screenshot From 2026-01-10 12-35-25" src="https://github.com/user-attachments/assets/fc2cda4c-d3a4-42f7-8ba9-6bb1ba0eb65e" />

#### Libreoffice
<img width="472" height="335" alt="Screenshot From 2026-01-10 12-30-00" src="https://github.com/user-attachments/assets/1dc4cec4-cf16-4478-858c-a98afb7c458c" />


#### Gimp:
<img width="471" height="472" alt="Screenshot From 2026-01-10 12-39-54" src="https://github.com/user-attachments/assets/aca1eb8a-f715-4da5-a3d2-0213a593208f" />

