### PR TITLE
Fixed install links #36

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -546,12 +546,12 @@ timeout = "120s"
 [[menu.sidebar]]
   parent = "sb-doc-install"
   name = "4diac IDE"
-  url = "/doc/installation/installation.html#_4diacide"
+  url = "/doc/installation/overview.html#_4diacide"
   weight = 1
 [[menu.sidebar]]
   parent = "sb-doc-install"
   name = "4diac FORTE"
-  url = "/doc/installation/installation.html#_4diacforte"
+  url = "/doc/installation/overview.html#_4diacforte"
   weight = 2
 [[menu.sidebar]]
   parent = "sb-doc-install"

--- a/layouts/doc/doc-overview.html
+++ b/layouts/doc/doc-overview.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
   <script>
     if (window.location.pathname.endsWith("/overview.html")) {
-      window.location.href = window.location.pathname.replace("/overview.html", "/");
+      window.location.href = window.location.pathname.replace("/overview.html", "/") + window.location.hash;
     }
   </script>
   {{ .Content }}


### PR DESCRIPTION
In addition the doc overview page forwarding now preservers location hashes.

Fixes: https://github.com/eclipse-4diac/4diac-website-hugo/issues/181