### PR TITLE
Simplified Documentation Menu

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -281,7 +281,7 @@ timeout = "120s"
   url = "/support/"
   [menu.main.params]
     description = """
-    support 4diac.
+    Support for using Eclipse 4diac.
     """
 
   [[menu.main]]
@@ -291,97 +291,18 @@ timeout = "120s"
   url = "/contribute/"
   [menu.main.params]
     description = """
-    contribute to 4diac.
+    Contribute to Eclipse 4diac.
     """
 
 [[menu.main]]
   name = "Documentation"
   weight = 6
   identifier = "documentation"
+  url = "/doc/"
   [menu.main.params]
     description = """
     Documentation for Eclipse 4diac. 
     """
-
-[[menu.main]]
-  name = "Getting Started"
-  weight = 1
-  identifier = "doc-getting_started"
-  parent = "documentation"
-
-[[menu.main]]
-  name = "Documentation Start"
-  url = "/doc/"
-  weight = 1
-  parent = "doc-getting_started"
-
-[[menu.main]]
-  name = "Learn about IEC 61499"
-  url = "/doc/intro/iec61499.html"
-  weight = 2
-  parent = "doc-getting_started"
-
-[[menu.main]]
-  name = "Understand the Eclipse 4diac Framework"
-  url = "/doc/intro/4diacframework.html"
-  weight = 3
-  parent = "doc-getting_started"
-
-[[menu.main]]
-  name = "Using Eclipse 4diac"
-  weight = 2
-  identifier = "doc-using"
-  parent = "documentation"
-
-[[menu.main]]
-  name = "Step by Step Tutorials"
-  url = "/doc/tutorials/"
-  weight = 1
-  parent = "doc-using"
-
-[[menu.main]]
-  name = "Install Eclipse 4diac"
-  url = "/doc/installation/"
-  weight = 2
-  parent = "doc-using"
-
-[[menu.main]]
-  name = "4diac IDE Examples"
-  url = "/doc/examples/"
-  weight = 3
-  parent = "doc-using"
-
-[[menu.main]]
-  name = "Frequently Asked Questions"
-  url = "/doc/faq.html"
-  weight = 4
-  parent = "doc-using"
-  
-[[menu.main]]
-  name = "Details"
-  weight = 3
-  identifier = "doc-details"
-  parent = "documentation" 
-
-[[menu.main]]
-  name = "IO Configuration for the Different Platforms"
-  url = "/doc/io_config/"
-  weight = 1
-  parent = "doc-details"
-
-[[menu.main]]
-  name = "Communication Protocols"
-  url = "/doc/communication/"
-  weight = 2
-  parent = "doc-details"
-
-[[menu.main]]
-  name = "Development of 4diac FORTE and 4diac IDE"
-  url = "/doc/development/"
-  weight = 2
-  parent = "doc-details"
-
-
 
 [[sidebar]]
     name = "News"


### PR DESCRIPTION
AS we now have the documentation side-bar and the documentation well integrated into the Eclipse 4diac web-page having only a link to the documentation main page is less confusing for new users.

As part of this commit the doucmentation was updated to the latest changes.