### PR TITLE
Add GSoC 2026 contributor introduction for Dimitris Kalligaridis

### DIFF
--- a/content/news/2026/2026-05-31-GSoC26-RefactoringTestingIntro.md
+++ b/content/news/2026/2026-05-31-GSoC26-RefactoringTestingIntro.md
@@ -1,0 +1,25 @@
+---
+title: "Introducing Our GSoC 2026 Contributor: Dimitris Kalligaridis"
+date: 2026-05-31T00:00:00-00:00
+categories: ["GSoC"]
+type: "newsitem"
+description: |
+  Welcoming Dimitris Kalligaridis, our Google Summer of Code 2026 contributor, working on automated testing for Type Management refactorings in Eclipse 4diac.
+---
+
+## Project: Strengthening Refactoring Quality through Automated Testing
+
+### Contributor: Dimitris Kalligaridis
+**Organization:** American College of Greece, Athens, Greece  
+**Field of Study:** IT, specializing in Intelligent Systems and Automation (Senior)  
+**Mentors:** Michael Oberlehner and the Eclipse 4diac Community
+
+---
+
+## About Me
+
+Hi, I am Dimitris, a senior student at the American College of Greece, graduating this summer with a BSc Hons in IT, specializing in Intelligent Systems and Automation. Last summer, I interned at Amazon as a Software Development Engineer in the Devices OS Security team, and this summer I am excited to be participating in Google Summer of Code 2026 with Eclipse 4diac.
+
+My project focuses on developing a comprehensive automated test suite for Type Management refactorings, aiming to ensure the stability and correctness of function block and data type operations.
+
+I am looking forward to contributing to the reliability of industrial automation tooling and learning from the 4diac team.


### PR DESCRIPTION
Adds a contributor introduction news post for the Google Summer of Code 2026 project *Strengthening Refactoring Quality through Automated Testing*.

- New file: `content/news/2026/2026-05-31-GSoC26-RefactoringTestingIntro.md`
- Follows the same structure as the existing GSoC 2026 progress post (`2026-05-28-GSoC26-ECCUpdate.md`): project header, contributor details, and an *About Me* section.

No template, layout, or asset changes.